### PR TITLE
Show toolbar menu (with list of colors) when you click in the icon button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckeditor-text-color-select",
-  "version": "0.0.2-2",
+  "version": "0.0.2-3",
   "description": "The text color selector for CKEditor 5",
   "keywords": [
     "ckeditor",

--- a/src/textcolorui.js
+++ b/src/textcolorui.js
@@ -123,7 +123,10 @@ export default class TextColorUI extends Plugin {
                 this.listenTo(buttonView, 'execute', () => dropdownView.buttonView.set({lastExecuted: option.model}));
 
                 return buttonView;
-            });
+			});
+			
+			// add open event to the action button inside splitButtonView
+			splitButtonView.actionView.delegate('execute').to(splitButtonView, 'open');
 
             // Make toolbar button enabled when any button in dropdown is enabled before adding separator and eraser.
             dropdownView.bind('isEnabled').toMany(buttons, 'isEnabled', (...areEnabled) => areEnabled.some(isEnabled => isEnabled));


### PR DESCRIPTION
This change allows to show the toolbar menu with the list of colors, once you clicked on the icon button.

![demo-click-icon](https://user-images.githubusercontent.com/1960482/62980730-fc0aab80-bdec-11e9-9c3b-9e6109f453ae.gif)

Also, I have included some exclusions in .gitignore file, and I've increased the version of the package.

Thanks.